### PR TITLE
Bugfix: use project.path for local maven group id

### DIFF
--- a/buildSrc/src/main/kotlin/plugin/localmaven/MavenPublish.kt
+++ b/buildSrc/src/main/kotlin/plugin/localmaven/MavenPublish.kt
@@ -12,6 +12,8 @@ import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.tasks.bundling.Jar
 import plugin.bean.RocketXBean
+import plugin.utils.MavenIdHelper.getMavenArtifactId
+import plugin.utils.MavenIdHelper.getMavenGroupId
 import plugin.utils.hasAndroidPlugin
 import plugin.utils.hasAppPlugin
 import plugin.utils.hasJavaPlugin
@@ -55,9 +57,9 @@ fun Project.mavenPublish(mRocketXBean: RocketXBean?) {
         }
     }
     // 获取 module 中定义的发布信息
-    val pomDesc = "library is ${this.name}"
-    val pomGroupId = "com.${this.name}"
-    val pomAftId = this.name as String
+    val pomGroupId = getMavenGroupId()
+    val pomAftId = getMavenArtifactId()
+    val pomDesc = "library is $pomGroupId: $pomAftId"
     val pomVersion = "1.0"
     mavenPublish(mRocketXBean, pomGroupId, pomAftId, pomVersion, pomDesc) {
         it.maven { artifactRepository ->

--- a/buildSrc/src/main/kotlin/plugin/utils/DependenciesHelper.kt
+++ b/buildSrc/src/main/kotlin/plugin/utils/DependenciesHelper.kt
@@ -9,6 +9,8 @@ import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollectio
 import org.gradle.api.internal.file.collections.DefaultConfigurableFileTree
 import plugin.ChildProjectDependencies
 import plugin.bean.RocketXBean
+import plugin.utils.MavenIdHelper.getMavenArtifactId
+import plugin.utils.MavenIdHelper.getMavenGroupId
 import java.io.File
 
 /**
@@ -84,7 +86,7 @@ class DependenciesHelper(val rocketXBean: RocketXBean?, var mProjectDependencies
                 // 需要根据RocketXBean配置，区分使用本地aar还是maven的依赖方式
                 if (enableLocalMaven) {
                     if (hasAndroidPlugin(projectWapper.project) || hasJavaPlugin(projectWapper.project)) {
-                        addMavenDependencyToProject(projectWapper.project.name, parentConfig.name, parentProject.key)
+                        addMavenDependencyToProject(projectWapper.project, parentConfig.name, parentProject.key)
                     }
                 } else {
                     //android  module or artifacts module
@@ -148,10 +150,13 @@ class DependenciesHelper(val rocketXBean: RocketXBean?, var mProjectDependencies
         project.dependencies.add(configName, map)
     }
 
-    fun addMavenDependencyToProject(aarName: String, configName: String, project: Project) {
+    fun addMavenDependencyToProject(mavenProject: Project, configName: String, project: Project) {
         // 改变依赖 这里后面需要修改成maven依赖
-        LogUtil.d("lzy addMavenDependencyToProject==>>com.${aarName}:${aarName}:1.0")
-        project.dependencies.add(configName, "com.${aarName}:${aarName}:1.0")
+        LogUtil.d("lzy addMavenDependencyToProject==>>${mavenProject.getMavenGroupId()}:${mavenProject.getMavenArtifactId()}:1.0")
+        project.dependencies.add(
+            configName,
+            "${mavenProject.getMavenGroupId()}:${mavenProject.getMavenArtifactId()}:1.0"
+        )
     }
 
     fun getAarByArtifacts(childProject: Project): MutableList<String> {

--- a/buildSrc/src/main/kotlin/plugin/utils/MavenIdHelper.kt
+++ b/buildSrc/src/main/kotlin/plugin/utils/MavenIdHelper.kt
@@ -1,0 +1,17 @@
+package plugin.utils
+
+import org.gradle.api.Project
+
+/**
+ * @author QuincyJiang
+ * Created at 2021/12/1.
+ */
+object MavenIdHelper {
+    fun Project.getMavenGroupId(): String {
+        return "com." + this.path.removePrefix(":").replace(":", ".")
+    }
+
+    fun Project.getMavenArtifactId(): String {
+        return project.name
+    }
+}


### PR DESCRIPTION
Use `project.path` for local maven group id
eg: log:impl -> "com.log.impl:impl:1.0.0"
      push:impl -> "com.push.impl:impl:1.0.0"